### PR TITLE
Configurate webpack configs for using es6 modules

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,7 +1,7 @@
-const { app, BrowserWindow, ipcMain, dialog, shell } = require('electron');
-const path = require('path');
-const { download } = require('electron-dl');
-const fs = require('fs');
+import { app, BrowserWindow, ipcMain, dialog, shell } from 'electron';
+import path from 'path';
+import { download } from 'electron-dl';
+import fs from 'fs';
 
 const createWindow = () => {
   const window = new BrowserWindow({

--- a/package.json
+++ b/package.json
@@ -2,13 +2,12 @@
   "name": "electron-app",
   "version": "1.0.0",
   "description": "Test electron task",
-  "main": "src/index.ts",
-  "type": "module",
+  "main": "dist/js/main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev:react": "webpack serve --config webpack.dev.js",
-    "dev:electron": "electron .",
-    "dev:app": "concurrently \"yarn dev:react\" \"electron .\"",
+    "dev:react": "webpack serve --config webpack/dev/webpack.react.dev.js",
+    "dev:electron": "webpack --config webpack/dev/webpack.electron.dev.js && electron .",
+    "dev:app": "concurrently \"yarn dev:react\" \"yarn dev:electron\"",
     "build:react": "webpack --config webpack.prod.js",
     "build:app": "yarn build:react && dev:electron"
   },

--- a/webpack/dev/webpack.dev.js
+++ b/webpack/dev/webpack.dev.js
@@ -1,5 +1,6 @@
-import { merge } from 'webpack-merge';
-import baseConfig from './webpack.config.js';
+const { merge } = require('webpack-merge');
+
+const baseConfig = require('../webpack.config.js');
 
 const devConfig = merge(baseConfig, {
   mode: 'development',
@@ -16,4 +17,4 @@ const devConfig = merge(baseConfig, {
   },
 });
 
-export default devConfig;
+module.exports = devConfig;

--- a/webpack/dev/webpack.electron.dev.js
+++ b/webpack/dev/webpack.electron.dev.js
@@ -1,0 +1,11 @@
+const { merge } = require('webpack-merge');
+
+const baseConfig = require('../webpack.config.js');
+
+const electronConfig = merge(baseConfig, {
+  mode: 'development',
+  entry: `${baseConfig.externals.path.electron}/main.ts`,
+  target: 'electron-main',
+});
+
+module.exports = electronConfig;

--- a/webpack/dev/webpack.react.dev.js
+++ b/webpack/dev/webpack.react.dev.js
@@ -1,0 +1,10 @@
+const { merge } = require('webpack-merge');
+
+const devConfig = require('./webpack.dev.js');
+
+const reactConfig = merge(devConfig, {
+  entry: `${devConfig.externals.path.src}/index.tsx`,
+  target: 'electron-renderer',
+});
+
+module.exports = reactConfig;

--- a/webpack/prod/webpack.prod.js
+++ b/webpack/prod/webpack.prod.js
@@ -1,6 +1,6 @@
 import { merge } from 'webpack-merge';
 
-import baseConfig from './webpack.config.js';
+import baseConfig from '../webpack.config.js';
 
 const prodConfig = merge(baseConfig, {
   mode: 'production',

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,28 +1,23 @@
-import path from 'path';
-import HtmlWebpackPlugin from 'html-webpack-plugin';
-import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-
-const __dirname = path.resolve();
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const PATHS = {
-  src: path.join(__dirname, './src'),
-  public: path.join(__dirname, './public'),
-  dist: path.join(__dirname, './dist'),
+  src: path.join(__dirname, '../src'),
+  public: path.join(__dirname, '../public'),
+  dist: path.join(__dirname, '../dist'),
+  electron: path.join(__dirname, '../electron'),
   assets: 'assets',
 };
 
 const config = {
-  entry: ['@babel/polyfill', `${PATHS.src}/index.tsx`],
-
   devtool: 'source-map',
 
   output: {
-    filename: 'index.js',
+    filename: 'js/[name].js',
     path: PATHS.dist,
     clean: true,
   },
-
-  target: 'electron-renderer',
 
   externals: {
     path: PATHS,
@@ -30,9 +25,9 @@ const config = {
 
   resolve: {
     alias: {
-      components: path.resolve(__dirname, './src/components'),
-      shared: path.resolve(__dirname, './src/shared'),
-      pages: path.resolve(__dirname, './src/pages'),
+      components: path.resolve(__dirname, '../src/components'),
+      shared: path.resolve(__dirname, '../src/shared'),
+      pages: path.resolve(__dirname, '../src/pages'),
     },
     extensions: ['.ts', '.tsx', '.js'],
   },
@@ -104,4 +99,4 @@ const config = {
   ],
 };
 
-export default config;
+module.exports = config;


### PR DESCRIPTION
Electron не поддерживает es6 модули в бандле, поэтому в `package.json` `module` указывать нельзя
Мы билдим все в `cjs`, и `main` в `package.json` вешаем на `dist`, потому что там все скомпилировалось в `cjs`